### PR TITLE
Add prompt to confirm ill-advised renaming when in a daily / Daily navigation conveniences

### DIFF
--- a/org-node.el
+++ b/org-node.el
@@ -2161,7 +2161,7 @@ which wraps this function."
     (let ((path (buffer-file-name)))
       (unless (equal "org" (file-name-extension path))
         (error "File doesn't end in .org: %s" path))
-      (when (or interactive
+      (when (or
                 ;; Be aware of "dailies" and don't touch
                 (and (or (not (bound-and-true-p org-journal-dir))
                          (not (string-prefix-p org-journal-dir path)))
@@ -2169,7 +2169,12 @@ which wraps this function."
                          (not (string-prefix-p
                                (expand-file-name org-roam-dailies-directory
                                                  org-roam-directory)
-                               path)))))
+                               path))))
+                (and interactive
+                     (yes-or-no-p "WARNING:
+You are currently in a daily file.
+Renaming according to the regular formula probably will not do what you want it to do. 
+Are you sure you want to proceed? ")))
         (let ((title (or (cadar (org-collect-keywords '("TITLE")))
                          (save-excursion
                            (without-restriction

--- a/org-node.el
+++ b/org-node.el
@@ -1904,10 +1904,14 @@ or next dailies with potential time gaps."
          (target-node
           (org-read-date nil nil offset nil current-node))
          (node-hash (gethash target-node org-node--candidate<>node))
-         (beginning-of-time 
-          (org-time-string-to-time "1976-06-21"))
+         (beginning-of-time
+          (if org-read-date-force-compatible-dates
+              (org-time-string-to-time "1976-06-21")
+            (org-time-string-to-time "1900-01-01")))
          (end-of-time
-          (org-time-string-to-time "2037-12-31")))
+          (if org-read-date-force-compatible-dates
+              (org-time-string-to-time "2037-01-01")
+            (org-time-string-to-time "2100-01-01"))))
     (cl-loop
      while (and (not node-hash) ;; while node not found
                 ;; and still within reasonable time range

--- a/org-node.el
+++ b/org-node.el
@@ -1850,36 +1850,37 @@ To behave like `org-roam-node-find' when creating new nodes, set
       (org-node--create input (org-id-new)))))
 
 ;;;###autoload
-(defun org-node-goto-daily (&optional offset)
-  "Go to a daily node with a time `offset' from the current buffer.
+  (defun org-node-goto-daily (&optional offset)
+    "Go to a daily node with a time `offset' from the current buffer.
 If called interactively, find the daily-note for a date using the calendar,
 creating it if necessary."
-  (interactive)
-  (let ((must-be-in-daily ;; if prefix makes reference to base date
-         (let ((prefix
-                ;; ('Some people, when confronted with a problem, think
-                ;;   "I know, I'll use regular expressions."
-                ;;   Now they have two problems.' —Jamie Zawinski)
-                "\\`\\(?:\\+\\{2\\}\\|-\\{2\\}\\)"))
-           ;; = two or more `+' or `-' at beginning of string
-           ;; = (rx (: bos (or (repeat 2 2 "+")
-           ;;                  (repeat 2 2 "-"))))
-           (string-match prefix offset))))
-    (if (and
-         (not (org-node--daily-note-p))
-         must-be-in-daily)
-        (user-error "Not in a daily-note.")
-      (let* ((current-node
-              (if must-be-in-daily
-                  (org-time-string-to-time
-                   (file-name-base buffer-file-name))
-                nil))
-             (target-node
-              (org-read-date nil nil offset nil current-node))
-             (node-hash (gethash target-node org-node--candidate<>node)))
-        (if node-hash
-            (org-node--goto node-hash)
-          (org-node--create target-node (org-id-new)))))))
+    (interactive)
+    (let ((must-be-in-daily ;; if prefix makes reference to base date
+           (if offset (let ((prefix
+                   ;; ('Some people, when confronted with a problem, think
+                   ;;   "I know, I'll use regular expressions."
+                   ;;   Now they have two problems.' —Jamie Zawinski)
+                   "\\`\\(?:\\+\\{2\\}\\|-\\{2\\}\\)"))
+              ;; = two or more `+' or `-' at beginning of string
+              ;; = (rx (: bos (or (repeat 2 2 "+")
+              ;;                  (repeat 2 2 "-"))))
+                        (string-match prefix offset))
+             nil)))
+      (if (and
+           (not (org-node--daily-note-p))
+           must-be-in-daily)
+          (user-error "Not in a daily-note.")
+        (let* ((current-node
+                (if must-be-in-daily
+                    (org-time-string-to-time
+                     (file-name-base buffer-file-name))
+                  nil))
+               (target-node
+                (org-read-date nil nil offset nil current-node))
+               (node-hash (gethash target-node org-node--candidate<>node)))
+          (if node-hash
+              (org-node--goto node-hash)
+            (org-node--create target-node (org-id-new)))))))
 
 ;;;###autoload
 (defun org-node-goto-prev-day ()

--- a/org-node.el
+++ b/org-node.el
@@ -1838,7 +1838,7 @@ To behave like `org-roam-node-find' when creating new nodes, set
     (when-let ((a (expand-file-name
                    (buffer-file-name (buffer-base-buffer))))
                (b (expand-file-name
-                   org-roam-daily-reflection-dailies-directory)))
+                   org-roam-dailies-directory)))
       (setq a (expand-file-name a))
       (if (and (eq major-mode 'org-mode)
                (unless (and a b (equal (file-truename a) (file-truename b)))


### PR DESCRIPTION
First commit:

(If user tries to call function interactively in a daily file, throw up a yes-or-no-p interactive prompt.)

(re: https://github.com/meedstrom/org-node/issues/24 )

Subsequent commits:

various convenience functions for navigating dailies (org-roam has these already, but I think it may be faster to use org-node, esp. on devices with speed issues, e.g., in Termux; will have to test)