### PR TITLE
revamp "goto-daily" functions

### DIFF
--- a/org-node.el
+++ b/org-node.el
@@ -1910,61 +1910,80 @@ creating it if necessary."
          (not (org-node--daily-note-p))
          must-be-in-daily)
         (user-error "Not in a daily-note.")
-      (let* ((current-node
-              (if must-be-in-daily
-                  (org-time-string-to-time
-                   (file-name-base buffer-file-name))
-                nil))
-             (target-node
-              (org-read-date nil nil offset nil current-node))
-             (node-hash (gethash target-node org-node--candidate<>node)))
-        (if node-hash
-            (org-node--goto node-hash)
-          (if (member direction '("--" "++")) ;; if next or prev & missing node
-              (org-node--find-next-daily-iterate
-               current-node direction (1+ range) span)
+      (if (member direction '("--" "++")) ;; if next or prev & missing node
+          (org-node--locate-offset-node
+           (file-name-base buffer-file-name)
+           direction range span)
+        (let* ((current-node
+                (if must-be-in-daily
+                    (org-time-string-to-time
+                     (file-name-base buffer-file-name))
+                  nil))
+               (target-node
+                (org-read-date nil nil offset nil current-node))
+               (node-hash (gethash target-node org-node--candidate<>node)))          
+          (if node-hash
+              (org-node--goto node-hash)
             (org-node--daily-not-found target-node)))))))
 
-(defun org-node--find-next-daily-iterate (current-node direction range span)
-  "Worker function for `org-node-goto-daily'. Handles looking up previous
-or next dailies with potential time gaps."
-  (let* ((offset
-          (concat direction (number-to-string range) span))
-         (target-node
-          (org-read-date nil nil offset nil current-node))
-         (node-hash (gethash target-node org-node--candidate<>node))
-         (beginning-of-time
-          (if org-read-date-force-compatible-dates
-              (org-time-string-to-time "1976-06-21")
-            (org-time-string-to-time "1900-01-01")))
-         (end-of-time
-          (if org-read-date-force-compatible-dates
-              (org-time-string-to-time "2037-01-01")
-            (org-time-string-to-time "2100-01-01"))))
-    (cl-loop
-     while (and (not node-hash) ;; while node not found
-                ;; and still within reasonable time range
-                (let ((target-node-time
-                       (org-time-string-to-time target-node)))
-                  (and
-                   (time-less-p beginning-of-time
-                                target-node-time)
-                   (time-less-p target-node-time
-                                end-of-time))))
-     do (progn
-          (setq range (1+ range))
-          (setq target-node
-                (org-read-date nil nil
-                               (concat direction (number-to-string range) span)
-                               nil current-node))
-          (setq node-hash (gethash target-node org-node--candidate<>node))))
-    (if node-hash
-        (org-node--goto node-hash)
-      (user-error (concat "Cannot find "
-                          (if (equal direction "--")
-                              "previous"
-                            "next")
-                          " daily entry.")))))
+(defun org-node--locate-offset-node (node direction range span)
+  "Given a reference `node', a `direction' for offset, a `range'
+of distance and a `span' [currently `span' is ignored], open the
+daily journal entry file of the appropriate date in the current
+window. This function is currently really just used for
+`org-node-goto-prev-day' and `org-node-goto-next-day' commands."
+  (unless (org-node--daily-note-p)
+    (user-error "Not in a daily-note"))
+  (setq n (or range 1))
+  (setq n (* n (if (equal direction "--")
+                   -1 1)))
+  (let* ((dailies (org-node--calculate-list-of-dailies-dates node))
+         (position
+          (when node 
+            (cl-position-if (lambda (candidate)
+                              (string=
+                               node
+                               candidate))
+                            dailies))))
+    (if position
+        (progn
+          (pcase n
+            ((pred (natnump))
+             (when (eq position (- (length dailies) 1))
+               (user-error "Already at newest note")))
+            ((pred (integerp))
+             (when (eq position 0)
+               (user-error "Already at oldest note"))))
+          (setq note (nth (+ position n) dailies))
+          (org-node--goto
+           (gethash note org-node--candidate<>node)))
+      (user-error "ERROR"))))
+
+(defun org-node--calculate-list-of-dailies-dates (node)
+  "Calculate a list of known dailies, adding
+`node' as part of the list in case `node' actually
+represents the date of an unknown/nascent dailies."
+  (org-node-cache-ensure)
+  (delete-dups ;; takes care of (a) the case that `node' actually exists
+               ;; and (b) cases of squiggle~ or #autosave or sync-conflict files
+               ;; that `org-nodes' may have entries for
+           (sort  ;; sort into calendrial order     
+            (cons node         ;; add in the current node in case it's not actually 
+             (let ((keys ())   ;; (yet) extant
+                   (titles ()))
+               (maphash (lambda (k v) (push (cons k v) keys)) org-nodes)
+               (let ((titles
+                      (cl-loop
+                       for key in keys
+                       collect (org-node-get-file-title-or-basename (cdr key)))))
+                 (cl-loop
+                  for title in titles
+                  when
+                  (string-match-p ;; match for YYYY-MM-DD nodes only
+                   "^\\(?:[0-9][0-9]\\)\\{1,2\\}-\\(?:1[012]\\|0?[1-9]\\)-\\(?:0?[1-9]\\|[12][0-9]\\|3[01]\\)$"
+                   title)
+                  collect title))))
+            'string<)))
 
 (defun org-node--daily-not-found (target-node)
   "Handles missing/nascent daily node look-up."
@@ -1979,17 +1998,34 @@ or next dailies with potential time gaps."
     (message "Cannot load requested file.
 (And org-roam is not available.)")))
 
+(defvar-keymap org-node--daily-repeat-next-prev
+  :doc "Use `-', `y', or `p' to move to the first extant previous daily entry,
+and `+', `t', or `n' to move to the first next extant daily entry."
+  "-" #'org-node-goto-prev-day ;; "decrease date"
+  "y" #'org-node-goto-prev-day ;; "yesterday"
+  "p" #'org-node-goto-prev-day ;; "previous date"
+  "+" #'org-node-goto-next-day ;; "decrease date"
+  "t" #'org-node-goto-next-day ;; "tomorrow"
+  "n" #'org-node-goto-next-day ;; "next date"
+  )
+
 ;;;###autoload
 (defun org-node-goto-prev-day ()
-  "Go to the day before the day of the current buffer."
+  "Go to the first extant daily before the day of the current buffer."
   (interactive)
-  (org-node-goto-daily "--" 1 "d"))
+  (org-node-goto-daily "--" 1 "d")
+  (set-transient-map org-node--daily-repeat-next-prev nil nil
+                     "Use `-', `p', or `y' to continue going back in time.\
+ Use `+', `n', or `t' to switch to moving forward in time."))
 
 ;;;###autoload
 (defun org-node-goto-next-day ()
-  "Go to the day after the day of the current buffer."
+  "Go to the next extant daily after the day of the current buffer."
   (interactive)
-  (org-node-goto-daily "++" 1 "d"))
+  (org-node-goto-daily "++" 1 "d")
+  (set-transient-map org-node--daily-repeat-next-prev nil nil
+                     "Use `+', `n', or `t' to continue moving forward in time.\
+ Use `-', `p', or `y' to switch to going back in time."))
 
 ;;;###autoload
 (defun org-node-goto-yesterday ()
@@ -3126,18 +3162,18 @@ heading, else the file-level node, whichever has an ID first."
     (append extra-files
             (cl-loop
              for file in (org-node-list-files t)
-             when (and (string-prefix-p dir file)
-                       (let ((file (file-name-nondirectory file)))
-                         (not (or (auto-save-file-name-p file)
-                                  (backup-file-name-p file)
-                                  (string-match "^\\." file)))))
+             when (and (string-prefix-p dir (file-truename file))
+                       (let ((file (file-name-nondirectory (file-truename file))))
+                         (not (or (auto-save-file-name-p (file-truename file))
+                                  (backup-file-name-p (file-truename file))
+                                  (string-match "^\\." (file-truename file))))))
              collect file))))
 
 (defun org-node-list-roam-files ()
   "Faster than `org-roam-list-files'."
   (require 'org-roam)
   (cl-loop for file in (org-node-list-files t)
-           when (string-prefix-p org-roam-directory file)
+           when (string-prefix-p org-roam-directory (file-truename file))
            collect file))
 
 (provide 'org-node)


### PR DESCRIPTION
- instead of stupidly looking up each possible daily one by one via trying `(gethash target-node org-node--candidate<>node)`, do this: create a list of all nodes from the "master hash table" `org-nodes` whose name or filebase have a "YYYY-MM-DD" format [this could break on some edge-cases, so possibly add some checks]; add the date of the current node to it; dedup the list in case the current node is already in the list and also to get rid of 'duplicate' \#backup.org\# or squiggle.org~ or sync-conflict entries; sort the list; find the position of the current node (extant or not) in the list; and then find the node with the appropriate date offset by "counting" `n` list items forward or back from the position of the current node in the list; and finally use `org-node--goto` on the hash of that node.
- the above also gets round the problem `org-roam` "next", "prev" commands have of not being able to navigate forward or back when the current buffer is a node that's not currently saved (possibly because it's a "phantom" entry the user has navigated to in order to find the next or previous entry around it).
- the new `org-node-goto-daily` function now should be more agnostic about whether `org-roam` is used at all, since it doesn't directly depend on file location (though this could potentially be an issue in some edge-case, depending on user file-naming patterns). although `org-node--daily-note-p` still makes reference to `org-roam-dailies-directory`. This function (`org-node--daily-note-p`) should probably be rewritten, though it's not currently clear how. The simple, brute-force thing would be to define a custom variable for `org-node` (e.g. `org-node-dailies-directory`) and check that. 
- change the "next" and "prev" commands to have "transient-map" repeat options. But probably better is to look-up properties of the `org-node` entry for the current buffer and check some properties (`:file-path` or `:tags`). Although this would run afoul of the issue of the current buffer not yet being saved (in the case of a new blank daily or a "phantom" daily). So maybe the easiest thing would just be to check something like `(file-name-sans-versions (file-name-nondirectory buffer-file-name))` and try to match it against a pre-defined (but user-configurable?) pattern, e.g. `<YYYY-MM-DD>.org`.
- ensure "truename" in `org-node-list-roam-files` and `org-node-list-roam-files` so that they don't return `nil`