### PR TITLE
Maybe fix `org-node--default-daily-whereami`

### DIFF
--- a/org-node.el
+++ b/org-node.el
@@ -1623,6 +1623,10 @@ format-constructs occur before these."
 (defun org-node--series-goto-previous (key &optional next)
   (let* ((series (alist-get (sxhash key) org-node--series-info))
          (here (funcall (plist-get series :whereami)))
+         (nascent-shift ;; check if buffer has org-node hash
+          (if (gethash here org-node--candidate<>node)
+              1 ;; if so, then offset by 1
+            0)) ;; otherwise, no offset
          (head nil))
     (unless (null here)
       (cl-loop for item in (plist-get series :sorted-items)
@@ -1637,7 +1641,7 @@ format-constructs occur before these."
                 t))
       (let ((to-check (if next
                           head
-                        (drop (1+ (length head))
+                        (drop (+ (length head) nascent-shift)
                               (plist-get series :sorted-items))))
             (target nil))
         ;; HACK: Keep trying items as long as :try-goto fails, because an item

--- a/org-node.el
+++ b/org-node.el
@@ -1572,14 +1572,17 @@ YYYY-MM-DD, but it does not verify."
 (defun org-node--default-daily-whereami ()
   (cl-labels ((verify-date (putative-date)
                 (and
-                 (string-match-p ;; NNNN-NN-NN format
+                 (string-match-p ;; is it in NNNN-NN-NN format?
                   (rx bol (= 4 digit) "-" (= 2 digit) "-" (= 2 digit) eol)
                   putative-date)
-                 (calendar-date-is-valid-p ;; and actual a Gregorian date
+                 (calendar-date-is-valid-p ;; and an actual Gregorian date?
                   (org-date-to-gregorian putative-date)))))
   (let ((basename (file-name-base
                    (buffer-file-name (buffer-base-buffer)))))
-    (when (verify-date basename)
+    (when 
+        ;; could have `(or ...)' here and re-apply `verify-date'
+        ;; if there is some case for the wild trick that I don't understand
+        (verify-date basename)
       basename))))
 
 ;; TODO: Handle %s, %V, %y...  is there a library?


### PR DESCRIPTION
- simplify and use `calendar.el` function to check if date is in the Gregorian calendar

I don't understand this part in the old function's `or`:

````
....
(when (or (string-match-p
               (rx bol (= 4 digit) "-" (= 2 digit) "-" (= 2 digit) eol)
               basename)
              ;; Wild trick: pretend to return a date even outside the dailies
              ;; dir, so that we can jump to "next" and "previous" relative to
              ;; when this file was created!
              (and (not (string-blank-p org-node-datestamp-format))
                   (string-match (org-node--make-regexp-for-time-format
                                  org-node-datestamp-format)
                                 basename)
                   (org-node--extract-ymd (match-string 0 basename)
                                          org-node-datestamp-format)))
      basename))
````

The old function just throws errors for buffers with names like `9999-01-05` or `1923-42-02` etc.

And I don't see why it does anything special outside of the dailies directory, since the rest of the old function doesn't seem to check for the directory anyway.