### PR TITLE
add font-locking to calendar view for dates with dailies

### DIFF
--- a/org-node.el
+++ b/org-node.el
@@ -119,7 +119,7 @@
   :group 'org)
 
 (defcustom org-node-mark-calendar-days-with-notes t
-  "Whether or not to mark days in the calendar for whic
+  "Whether or not to mark days in the calendar for which
 a daily note is present."
   :group 'org-node
   :type boolean)

--- a/org-node.el
+++ b/org-node.el
@@ -122,7 +122,7 @@
   "Whether or not to mark days in the calendar for which
 a daily note is present."
   :group 'org-node
-  :type boolean)
+  :type 'boolean)
 
 (defcustom org-node-rescan-functions nil
   "Hook run after scanning specific files.

--- a/org-node.el
+++ b/org-node.el
@@ -101,6 +101,10 @@
 (defvar org-roam-dailies-directory)
 (defvar org-super-links-backlink-into-drawer)
 
+;; calendar hooks (not sure where to put them)\(add-hook 'calendar-today-visible-hook #'org-node--dailies-calendar-mark-entries)
+(add-hook 'calendar-today-visible-hook #'org-node--dailies-calendar-mark-entries)
+(add-hook 'calendar-today-invisible-hook #'org-node--dailies-calendar-mark-entries)
+
 
 ;;;; Faces
   (defface org-node-dailies-calendar-note
@@ -726,9 +730,6 @@ In broad strokes:
                       (calendar-mark-visible-date
                        mdy-list-date
                        'org-node-dailies-calendar-note)))))))
-
-(add-hook 'calendar-today-visible-hook #'org-node--dailies-calendar-mark-entries)
-(add-hook 'calendar-today-invisible-hook #'org-node--dailies-calendar-mark-entries)
 
 
 ;;;; Scanning

--- a/org-node.el
+++ b/org-node.el
@@ -107,7 +107,7 @@
 
 
 ;;;; Faces
-  (defface org-node-dailies-calendar-note
+(defface org-node-dailies-calendar-note
   '((t :inherit (org-link) :underline nil))
   "Face for dates with a daily-note in the calendar."
   :group 'org-node-faces)

--- a/org-node.el
+++ b/org-node.el
@@ -101,10 +101,6 @@
 (defvar org-roam-dailies-directory)
 (defvar org-super-links-backlink-into-drawer)
 
-;; calendar hooks (not sure where to put them)\(add-hook 'calendar-today-visible-hook #'org-node--dailies-calendar-mark-entries)
-(add-hook 'calendar-today-visible-hook #'org-node--dailies-calendar-mark-entries)
-(add-hook 'calendar-today-invisible-hook #'org-node--dailies-calendar-mark-entries)
-
 
 ;;;; Faces
 (defface org-node-dailies-calendar-note
@@ -604,7 +600,10 @@ When called from Lisp, peek on any hash table HT."
         (advice-add 'rename-file :after #'org-node--handle-rename)
         (advice-add 'delete-file :after #'org-node--handle-delete)
         (org-node-cache-ensure 'must-async t)
-        (org-node--maybe-adjust-idle-timer))
+        (org-node--maybe-adjust-idle-timer)
+        ;; calendar hooks (not sure where to put them)
+        (add-hook 'calendar-today-visible-hook #'org-node--dailies-calendar-mark-entries)
+        (add-hook 'calendar-today-invisible-hook #'org-node--dailies-calendar-mark-entries))
     (cancel-timer org-node--idle-timer)
     (remove-hook 'after-save-hook #'org-node--handle-save)
     (remove-hook 'org-node-creation-hook #'org-node--dirty-ensure-node-known)
@@ -612,7 +611,10 @@ When called from Lisp, peek on any hash table HT."
     (remove-hook 'org-roam-post-node-insert-hook #'org-node--dirty-ensure-link-known)
     (advice-remove 'org-insert-link #'org-node--dirty-ensure-link-known)
     (advice-remove 'rename-file #'org-node--handle-rename)
-    (advice-remove 'delete-file #'org-node--handle-delete)))
+    (advice-remove 'delete-file #'org-node--handle-delete)
+    ;; calendar hooks (not sure where to put them)
+    (remove-hook 'calendar-today-visible-hook #'org-node--dailies-calendar-mark-entries)
+    (remove-hook 'calendar-today-invisible-hook #'org-node--dailies-calendar-mark-entries)))
 
 (defun org-node--handle-rename (file newname &rest _)
   "Arrange to scan NEWNAME for nodes and links, and forget FILE."


### PR DESCRIPTION
add optional calendar integration

- optionally add font-locking to calendar display for days for which a daily is
present according to `org-node--series-info` (like what org-roam does)

(not sure where hooks should really go)