### PR TITLE
Set node in org-node-capture-target with proposed title

### DIFF
--- a/org-node.el
+++ b/org-node.el
@@ -2230,10 +2230,12 @@ type the name of a node that does not exist.  That enables this
   (let (title node id)
     (if org-node-proposed-title
         ;; Was called from `org-node-create', so the user had typed the
-        ;; title and no such node exists yet
+        ;; title and no such node exists yet, or it is during capture
+        ;; and the title and id are proposed.
         (progn
           (setq title org-node-proposed-title)
-          (setq id org-node-proposed-id))
+          (setq id org-node-proposed-id)
+          (setq node (gethash title org-node--candidate<>node)))
       ;; Was called from `org-capture', which means the user has not yet typed
       ;; the title; let them type it now
       (let ((input (completing-read "Node: " #'org-node-collection


### PR DESCRIPTION
When capturing via org-protocol, we first set te proposed title and id.

In this case, check if there is an existing node, otherwise this function errors trying to open the file or buffer as one or both already exist.

This stops the org-protocol capture from silently "doing nothing", and allows you to add notes to an existing captured node if desired.

This allows me to use it with a workflow based on `org-roam` (without desiring to use `fake-roam`)

```elisp
  (defun my-org-node-protocol-open-ref (info)
    "Process an org-protocol://roam-ref?ref= style url with INFO.

It opens or creates a note with the given ref.

  javascript:location.href = \\='org-protocol://roam-ref?template=r&ref=\\='+ \\
        encodeURIComponent(location.href) + \\='&title=\\=' + \\
        encodeURIComponent(document.title) + \\='&body=\\=' + \\
        encodeURIComponent(window.getSelection())"
    (unless (plist-get info :ref)
      (user-error "No ref key provided"))
    (let ((ref (plist-get info :ref))
          (title (plist-get info :title))
          (body (plist-get info :body)))
      (setq my-org-node-ref-capture-ref ref)
      (setq my-org-node-ref-capture-title title)
      (setq my-org-node-ref-capture-body body)
      (setq org-node-ask-directory (file-truename "~/Sync/org/roam/references"))
      )
    (unwind-protect
        (org-capture nil "r")
      (setq my-org-node-ref-capture-ref nil)
      (setq my-org-node-ref-capture-title nil)
      (setq my-org-node-ref-capture-body nil))
      (setq org-node-ask-directory (file-truename "~/Sync/org/roam")))

  (push '("org-roam-ref"
          :protocol "roam-ref"
          :function my-org-node-protocol-open-ref
          :kill-client t ;; If I use C-g to abort, do not wait in protocol handler
          )
        org-protocol-protocol-alist)
```

The "r" capture template is set to call

```elisp
  (defun my-org-node-capture-target ()
    (when my-org-node-ref-capture-title
      (setq org-node-proposed-title my-org-node-ref-capture-title)
      ;; must set ID too, there is an expectation of it in org-node
      (setq org-node-proposed-id (org-id-new)))
    (unwind-protect
        (org-node-capture-target)

      (setq org-node-proposed-title nil)
      (setq org-node-proposed-id nil)))
```