### PR TITLE
use thing-at-point to add default input to org-node-find

### DIFF
--- a/org-node.el
+++ b/org-node.el
@@ -1119,7 +1119,8 @@ To behave like Org-roam when creating new nodes,
 set `org-node-creation-fn' to `org-node-new-via-roam-capture'."
   (interactive)
   (org-node-cache-ensure)
-  (let* ((input (org-node-read-candidate "Visit or create node: " t))
+  (let* ((input (org-node-read-candidate "Visit or create node: " t
+                                         (thing-at-point 'symbol)))
          (_ (when (string-blank-p input)
               (setq input (funcall org-node-blank-input-title-generator))))
          (node (gethash input org-node--candidate<>entry)))


### PR DESCRIPTION
When I invoke org-node-find interactively, I would like the default input be the symbol under the cursor.
This change is to make it so.