### PR TITLE
Make capturing more flexible by adding parameters to org-node-capture-target

### DIFF
--- a/README.org
+++ b/README.org
@@ -272,6 +272,13 @@ The secret sauce is =(function org-node-capture-target)=.  Examples:
          :immediate-finish t)))
 #+end_src
 
+The behavior of =org-node-capture-target= can be influenced via parameters passed in a plist. In order
+to do so, the result has to be wrapped in a nullary lambda function in the capture template, e.g.,
+=(function (lambda () (org-node-capture-target '(:path "~/org/articles"))))=. The following parameters exist:
+
+- =:path=: Provide the path of the directory in which the new file will be created
+- =:ask_path=: Always ask for the path, even if ~org-node-file-directory-ask~ is configured otherwise
+
 With that done, you can optionally configure the everyday commands =org-node-find= & =org-node-insert-link= to outsource to org-capture when they try to create new nodes:
 
 #+begin_src elisp


### PR DESCRIPTION
This is a proposal to make capturing using `org-capture` a bit more flexible such that some use-cases that `org-roam-capture` allows can also be handled without extending `org-capture`.

One such use-case is the ability to provide a directory in which a new file is to be generated per template. Currently, `org-node` works around this by allowing the user to configure whether she should be asked for the folder when a new file is created ... but it would be nicer if one could set specific folders for specific templates.

This pull-request adds the possibility to provide a plist with parameters to `org-node-capture-template` for
influencing the path for a new file. For usage in a capture template, In the result has to be wrapped in a nullary lambda function in the capture template:

~~~ elisp
(function (lambda () (org-node-capture-target '(:path "~/org/articles"))))
~~~

(the change is backward compatible, i.e., `(function org-node-capture-target)` still works.)

The following parameters exist:
- `:path`: Provide the path of the directory in which the new file will be created
- `:ask_path` Always ask for the path, even if `org-node-file-directory-ask` is configured otherwise

Possibly, a few more use-cases could be tackled with this approach.

