### PR TITLE
Dev2 feat parent node and path function

### DIFF
--- a/org-node.el
+++ b/org-node.el
@@ -1146,10 +1146,6 @@ type the name of a node that does not exist.  That enables this
               (org-node-goto parent-node)
             (user-error "No node found with ID: %s" parent-id))
 	(org-node-new-file-parameterized org-capture-plist))))
-
-  ;;(if-let* ((node (org-capture-get :existing-node)))
-  ;;    (org-node-goto node t)
-  ;;  (org-node-new-file-parameterized org-capture-plist))
   (when (eq (org-capture-get :type) 'plain)
     ;; Emulate part of `org-capture-place-plain-text'.  We cannot just put the
     ;; capture property :target-entry-p t, because this may be a file-level


### PR DESCRIPTION
Regarding the discussion in #141 : with the proposed change by @meedstrom and these additions, I now get the following to work:

~~~ emacs-lisp
("x" "Capture text into node with the node path provided by a function `bg-node-path-query'"
 entry
 #'org-node-capture-target 
 "%?"
 :path bg-node-path-query 
 )


~~~ emacs-lisp
("Y" "Capture text into node and always ask for path, no matter what the default setting is"
 entry
 #'org-node-capture-target 
 "%?"
 :ask-path t
 )
~~~

~~~ emacs-lisp
("X" "Capture into a file with given id"
 entry
 #'org-node-capture-target

 "* %(org-capture-get :title)\n:PROPERTIES:\n:EMAIL:\n:PHONE:\n:ALIAS:\n:NICKNAME:\n:IGNORE:\n:ICON:\n:NOTE:\n:ADDRESS:\n:BIRTHDAY:\n:ID: %(org-capture-get :id)\n:END:\n"
 :parent-id-if-new "249506ab-d89c-4419-aecd-70d7c314ce36"
 )
~~~