### PR TITLE
RFC: Add dependency cond-let

### DIFF
--- a/org-node-backlink.el
+++ b/org-node-backlink.el
@@ -23,6 +23,7 @@
 (require 'cl-lib)
 (require 'fileloop)
 (require 'llama)
+(require 'cond-let)
 (require 'org-mem)
 (require 'org-mem-updater)
 (require 'org-node)
@@ -452,7 +453,7 @@ To force an update at any time, use one of these commands:
               (org-node--assert-transclusion-safe)
               (let ((user-is-editing (buffer-modified-p)))
                 (dolist (id (delete-dups ids))
-                  (if-let* ((pos (and id (org-find-property "ID" id))))
+                  (if-let ((pos (and id (org-find-property "ID" id))))
                       (progn (goto-char pos)
                              (org-node-backlink--fix-nearby))
                     (error "Could not find ID %s in file %s" id file)))
@@ -487,7 +488,7 @@ Or if KIND is symbol `update-drawers', `del-drawers', `update-props', or
 (defun org-node-backlink--fix-nearby-property (&optional remove)
   "Update the :BACKLINKS: property in the current entry.
 If REMOVE is non-nil, remove it instead."
-  (when-let* ((prop-pos (car (org-get-property-block))))
+  (when-let ((prop-pos (car (org-get-property-block))))
     (when (get-text-property prop-pos 'read-only)
       ;; Because `org-entry-put' is so unsafe that it inhibits read-only
       (error "org-node-backlink: Area seems to be read-only at %d in %s"
@@ -636,17 +637,17 @@ If REMOVE non-nil, remove it instead."
         (org-node--assert-transclusion-safe)
         (let ((origin-id (org-entry-get-with-inheritance "ID")))
           (when (and origin-id (not (equal origin-id target-id)))
-            (when-let* ((origin-title
-                         (save-excursion
-                           (without-restriction
-                             (goto-char org-entry-property-inherited-from)
-                             (or (org-get-heading t t t t)
-                                 (org-get-title))))))
+            (when-let ((origin-title
+                        (save-excursion
+                          (without-restriction
+                            (goto-char org-entry-property-inherited-from)
+                            (or (org-get-heading t t t t)
+                                (org-get-title))))))
 
               (org-node--with-quick-file-buffer target-file
                 :about-to-do "Org-node going to add backlink in target of link you just inserted"
                 (org-node--assert-transclusion-safe)
-                (if-let* ((pos (org-find-property "ID" target-id)))
+                (if-let ((pos (org-find-property "ID" target-id)))
                     (progn (goto-char pos)
                            (org-node-backlink--add-nearby origin-id origin-title))
                   (message "`org-node-backlink--add-in-target' could not find ID %s in file %s"
@@ -660,7 +661,7 @@ If REMOVE non-nil, remove it instead."
 
 (defun org-node-backlink--add-to-property (id title)
   "Insert a link with ID and TITLE into nearby :BACKLINKS: property."
-  (when-let* ((prop-pos (car (org-get-property-block))))
+  (when-let ((prop-pos (car (org-get-property-block))))
     (when (get-text-property prop-pos 'read-only)
       ;; Because `org-entry-put' is so unsafe that it inhibits read-only
       (error "org-node-backlink: Area seems to be read-only at %d in %s"
@@ -773,3 +774,15 @@ See Info node `(org-node)'."
 (provide 'org-node-backlink)
 
 ;;; org-node-backlink.el ends here
+
+;; Local Variables:
+;; checkdoc-spellcheck-documentation-flag: nil
+;; checkdoc-verb-check-experimental-flag: nil
+;; emacs-lisp-docstring-fill-column: 72
+;; read-symbol-shorthands: (("and$"      . "cond-let--and$")
+;;                          ("and>"      . "cond-let--and>")
+;;                          ("and-let"   . "cond-let--and-let")
+;;                          ("if-let"    . "cond-let--if-let")
+;;                          ("when-let"  . "cond-let--when-let")
+;;                          ("while-let" . "cond-let--while-let"))
+;; End:

--- a/org-node-context.el
+++ b/org-node-context.el
@@ -14,6 +14,8 @@
 (require 'magit-section)
 (require 'repeat)
 (require 'map)
+(require 'cond-let)
+(require 'llama)
 (eval-when-compile
   (require 'org)
   (require 'org-node)
@@ -94,7 +96,7 @@ time that context was shown in a visible window.  Including:
 (defun org-node-context-history-go-back ()
   "Show the last context."
   (interactive () org-node-context-mode)
-  (when-let* ((last (pop org-node-context--past)))
+  (when-let ((last (pop org-node-context--past)))
     (push org-node-context--current
           org-node-context--future)
     (org-node-context--refresh nil last t)))
@@ -102,7 +104,7 @@ time that context was shown in a visible window.  Including:
 (defun org-node-context-history-go-forward ()
   "Show the next context."
   (interactive () org-node-context-mode)
-  (when-let* ((next (pop org-node-context--future)))
+  (when-let ((next (pop org-node-context--future)))
     (push org-node-context--current
           org-node-context--past)
     (org-node-context--refresh nil next t)))
@@ -127,7 +129,7 @@ time that context was shown in a visible window.  Including:
 ;; TODO: Solve problem if truncating away a :END: or #+END_... but not #+BEGIN,
 ;; or vice versa.
 ;; (defun org-node-context--truncate-buffer ()
-;;   (when-let* ((cutoff org-node-context-truncate-to-lines))
+;;   (when-let ((cutoff org-node-context-truncate-to-lines))
 ;;     (when (> (line-number-at-pos) cutoff)
 ;;       (forward-line (- cutoff))
 ;;       (delete-region (point-min) (point)))
@@ -304,7 +306,7 @@ Repeatable on the last key of a key sequence if
 (defun org-node-context-toggle ()
   "Show the main context buffer, or hide it if already showing."
   (interactive)
-  (if-let* ((win (get-buffer-window org-node-context-main-buffer 'visible)))
+  (if-let ((win (get-buffer-window org-node-context-main-buffer 'visible)))
       (quit-window nil win)
     (let ((buf (get-buffer-create org-node-context-main-buffer)))
       (when (derived-mode-p 'org-mode)
@@ -336,7 +338,7 @@ otherwise call the latter."
 
 (defun org-node-context--displaying-p (buf id)
   "Is BUF displaying context for ID?"
-  (when-let* ((buf (get-buffer (or buf org-node-context-main-buffer))))
+  (when-let ((buf (get-buffer (or buf org-node-context-main-buffer))))
     (equal id (buffer-local-value 'org-node-context--current buf))))
 
 (defun org-node-context-refresh-this-buffer (&rest _)
@@ -385,12 +387,12 @@ that buffer."
         (setq header-line-format
               (concat "Context for \"" (org-mem-entry-title node) "\""))
         (magit-insert-section (org-node-context :root)
-          (when-let* ((links (org-mem-id-links-to-entry node)))
+          (when-let ((links (org-mem-id-links-to-entry node)))
             (magit-insert-section (org-node-context :id-links)
               (magit-insert-heading "ID backlinks:")
               (org-node-context--insert-backlink-sections links)
               (insert "\n")))
-          (when-let* ((links (org-mem-roam-reflinks-to-entry node)))
+          (when-let ((links (org-mem-roam-reflinks-to-entry node)))
             (magit-insert-section (org-node-context :reflinks)
               (magit-insert-heading "Ref backlinks:")
               (org-node-context--insert-backlink-sections links)
@@ -402,7 +404,7 @@ that buffer."
   "Insert a section displaying a preview of LINK."
   (dolist (link (sort links #'org-node-context--origin-title-lessp))
     (let* ((entry (org-node-context--get-link-origin link))
-           (breadcrumbs (if-let* ((olp (org-mem-olpath-with-file-title entry)))
+           (breadcrumbs (if-let ((olp (org-mem-olpath-with-file-title entry)))
                             (string-join olp " > ")
                           "Top")))
       (magit-insert-section (org-node-context link)
@@ -523,3 +525,15 @@ No-op if user option `org-node-context-persist-on-disk' is nil."
 (provide 'org-node-context)
 
 ;;; org-node-context.el ends here
+
+;; Local Variables:
+;; checkdoc-spellcheck-documentation-flag: nil
+;; checkdoc-verb-check-experimental-flag: nil
+;; emacs-lisp-docstring-fill-column: 72
+;; read-symbol-shorthands: (("and$"      . "cond-let--and$")
+;;                          ("and>"      . "cond-let--and>")
+;;                          ("and-let"   . "cond-let--and-let")
+;;                          ("if-let"    . "cond-let--if-let")
+;;                          ("when-let"  . "cond-let--when-let")
+;;                          ("while-let" . "cond-let--while-let"))
+;; End:

--- a/org-node-seq.el
+++ b/org-node-seq.el
@@ -29,6 +29,8 @@
 (require 'transient)
 (require 'org-node)
 (require 'org-mem)
+(require 'llama)
+(require 'cond-let)
 (defvar org-node-proposed-seq)
 (defvar org-mem--next-message)
 (declare-function org-entry-get-with-inheritance "org")
@@ -53,7 +55,7 @@ For KEY, NAME and CAPTURE, see `org-node-seq-defs'."
                       (cons (concat sortstr " " (org-mem-entry-title node))
                             (org-mem-entry-id node)))))
     :whereami (lambda ()
-                (when-let* ((sortstr (org-entry-get nil ,prop t))
+                (when-let ((sortstr (org-entry-get nil ,prop t))
                             (node (org-node-at-point)))
                   (concat sortstr " " (org-mem-entry-title node))))
     :prompter (lambda (key)
@@ -198,7 +200,7 @@ The latter uses a sloppy algorithm so not all formats work, see
           (match-string 0 clipped-name)
         ;; Even in a non-daily file, pretend it is a daily if possible,
         ;; to allow entering the sequence at a more relevant date
-        (when-let* ((stamp (org-node-extract-file-name-datestamp path)))
+        (when-let ((stamp (org-node-extract-file-name-datestamp path)))
           (org-node-seq-extract-ymd stamp org-node-file-timestamp-format))))))
 
 ;; TODO: Handle %s, %V, %y...  is there a library?
@@ -721,3 +723,15 @@ not exist."
 (provide 'org-node-seq)
 
 ;;; org-node-seq.el ends here
+
+;; Local Variables:
+;; checkdoc-spellcheck-documentation-flag: nil
+;; checkdoc-verb-check-experimental-flag: nil
+;; emacs-lisp-docstring-fill-column: 72
+;; read-symbol-shorthands: (("and$"      . "cond-let--and$")
+;;                          ("and>"      . "cond-let--and>")
+;;                          ("and-let"   . "cond-let--and-let")
+;;                          ("if-let"    . "cond-let--if-let")
+;;                          ("when-let"  . "cond-let--when-let")
+;;                          ("while-let" . "cond-let--while-let"))
+;; End:

--- a/org-node.el
+++ b/org-node.el
@@ -7,7 +7,7 @@
 ;; URL:      https://github.com/meedstrom/org-node
 ;; Created:  2024-04-13
 ;; Keywords: org, hypermedia
-;; Package-Requires: ((emacs "29.1") (llama "1.0") (magit-section "4.3.0") (org-mem "0.32.0"))
+;; Package-Requires: ((emacs "29.1") (cond-let "0.2") (llama "1.0") (magit-section "4.3.0") (org-mem "0.32.0"))
 
 ;;; Commentary:
 
@@ -130,6 +130,7 @@
 (require 'cl-lib)
 (require 'fileloop)
 (require 'llama)
+(require 'cond-let)
 (require 'org-faces)
 (require 'org-mem)
 (require 'org-mem-updater)
@@ -486,11 +487,11 @@ aliases."
 (defun org-node-prepend-olp (node title)
   "Prepend NODE\\='s outline path to TITLE."
   (list title
-        (if-let* ((fontified-ancestors
-                   (cl-loop
-                    for ancestor in (org-mem-olpath-with-file-title node)
-                    collect
-                    (propertize ancestor 'face 'org-node-parent))))
+        (if-let ((fontified-ancestors
+                  (cl-loop
+                   for ancestor in (org-mem-olpath-with-file-title node)
+                   collect
+                   (propertize ancestor 'face 'org-node-parent))))
             (concat (string-join fontified-ancestors " > ") " > ")
           "")
         ""))
@@ -697,7 +698,7 @@ used as INITIAL-INPUT in `completing-read'."
   (when (and (org-mem-entry-id entry)
              (funcall org-node-filter-fn entry))
     (dolist (ref (org-mem-entry-roam-refs entry))
-      (puthash (concat (when-let* ((type (gethash ref org-mem--roam-ref<>type)))
+      (puthash (concat (when-let ((type (gethash ref org-mem--roam-ref<>type)))
                          (propertize (concat type ":") 'face 'org-node-cite-type))
                        (propertize ref 'face 'org-node-cite))
                entry
@@ -1275,7 +1276,7 @@ type the name of a node that does not exist.  That enables this
   ;; expansions %(org-capture-get :title) and %(org-capture-get :id) in the
   ;; template string.
   (apply #'org-capture-put (org-node-capture-infer-title-etc))
-  (if-let* ((node (org-capture-get :existing-node)))
+  (if-let ((node (org-capture-get :existing-node)))
       (org-node-goto node t)
     (org-node-new-file (org-capture-get :title)
                        (org-capture-get :id))
@@ -2245,8 +2246,8 @@ user quits, do not apply any modifications."
             (setq default-directory
                   (read-directory-name
                    "Directory with Org notes to operate on: "))))
-      (when-let* ((bufs (seq-filter (##string-search "*grep*" (buffer-name %))
-                                    (buffer-list))))
+      (when-let ((bufs (seq-filter (##string-search "*grep*" (buffer-name %))
+                                   (buffer-list))))
         (when (yes-or-no-p "Kill other *grep* buffers to be sure this works?")
           (mapc #'kill-buffer bufs)))
       (let* ((filename (file-relative-name (read-file-name "File to rename: ")))
@@ -2917,7 +2918,7 @@ As bonus, do not land on an inlinetask, seek a real heading."
 (defun org-node-complete-at-point ()
   "Expand word at point to a known node title, and linkify.
 Designed for `completion-at-point-functions'."
-  (when-let* ((bounds (bounds-of-thing-at-point 'word)))
+  (when-let ((bounds (bounds-of-thing-at-point 'word)))
     (and (not (org-in-src-block-p))
          (not (save-match-data (org-in-regexp org-link-any-re)))
          (list (car bounds)
@@ -2926,7 +2927,7 @@ Designed for `completion-at-point-functions'."
                :exclusive 'no
                :exit-function
                (lambda (text _)
-                 (when-let* ((id (gethash text org-mem--title<>id)))
+                 (when-let ((id (gethash text org-mem--title<>id)))
                    (atomic-change-group
                      (delete-char (- (length text)))
                      (insert (org-link-make-string (concat "id:" id) text)))
@@ -2961,7 +2962,7 @@ the same link in its ROAM_REFS property, visit that node rather than
 following the link normally.
 
 If already visiting that node, then follow the link normally."
-  (when-let* ((url (thing-at-point 'url)))
+  (when-let ((url (thing-at-point 'url)))
     ;; Rarely more than one valid target
     (let* ((target (car (org-mem--split-roam-refs-field url)))
            (found (cl-loop for node in (org-mem-all-id-nodes)
@@ -3450,3 +3451,15 @@ ENTRY should be an `org-mem-entry' object."
 (provide 'org-node)
 
 ;;; org-node.el ends here
+
+;; Local Variables:
+;; checkdoc-spellcheck-documentation-flag: nil
+;; checkdoc-verb-check-experimental-flag: nil
+;; emacs-lisp-docstring-fill-column: 72
+;; read-symbol-shorthands: (("and$"      . "cond-let--and$")
+;;                          ("and>"      . "cond-let--and>")
+;;                          ("and-let"   . "cond-let--and-let")
+;;                          ("if-let"    . "cond-let--if-let")
+;;                          ("when-let"  . "cond-let--when-let")
+;;                          ("while-let" . "cond-let--while-let"))
+;; End:


### PR DESCRIPTION
This lets me keep `if-let`, `when-let` rather than rename them all to `if-let*`, `when-let*` as Emacs 31 wants.  Upstream discussion https://debbugs.gnu.org/cgi/bugreport.cgi?bug=+73853

( An alternative is to "undeprecate" them in a Makefile like https://github.com/tarsius/llama/commit/c94a3825da6cfe8e248536c8fc2212e89d2ae8f6 )

The rest of cond-let looks super handy, so that's a bonus. I'm in love with `and$` and `and>`.

Finally, the library needs testers. https://github.com/tarsius/cond-let/wiki/Status